### PR TITLE
hey

### DIFF
--- a/rss2lj.rb
+++ b/rss2lj.rb
@@ -79,6 +79,7 @@ class LiveJournal
   def most_recent_update
     post_params = self.base_params.merge({
       'selecttype' => 'lastn',
+      'ver' => '1',
       'howmany' => 1,
     })    
     response = @server.call('LJ.XMLRPC.getevents', post_params)


### PR DESCRIPTION
hey, this solves a problem if you have utf8 characters in your posts.

ran into this problem puling from tumblr, gives an error before:

/usr/lib/ruby/1.8/xmlrpc/client.rb:414:in `call': Client error: Protocol version mismatch: Cannot display/edit a Unicode post with a non-Unicode client. Please see http://www.livejournal.com/support/encodings.bml for more information. (XMLRPC::FaultException)
    from /home/corprew/rss2lj/rss2lj.rb:84:in`most_recent_update'
    from /home/corprew/rss2lj/rss2lj.rb:121

and success after.  don't know what other calls might need this, I'll submit a pull request if i find others over time.

Thanks,

Corprew
